### PR TITLE
Add homepage and repository links

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "1.0.1",
   "description": "This plugin lazy loads image processed by gatsby-remark-images plugin",
   "main": "index.js",
+  "homepage": "https://github.com/1kohei1/gatsby-remark-lazy-load",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/1kohei1/gatsby-remark-lazy-load.git"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Thanks for this plugin! Really useful for the meantime until https://github.com/gatsbyjs/gatsby/issues/15716 is implemented!

Just a quick PR to add links for the homepage and repository fields, so that they show up on npm:

<img width="407" alt="Screen Shot 2019-07-25 at 11 16 41" src="https://user-images.githubusercontent.com/1935696/61898241-bd5c9200-aecd-11e9-99ed-3c88201c1f0f.png">
